### PR TITLE
PMM-720: don't try to parse fingerprint for Mongo

### DIFF
--- a/app/instance/subsystem.go
+++ b/app/instance/subsystem.go
@@ -23,36 +23,50 @@ import (
 	"github.com/percona/pmm/proto"
 )
 
+const (
+	SubsystemOS = iota + 1
+	SubsystemAgent
+	SubsystemMySQL
+	SubsystemMongo
+)
+
+const (
+	SubsystemNameOS    = "os"
+	SubsystemNameAgent = "agent"
+	SubsystemNameMySQL = "mysql"
+	SubsystemNameMongo = "mongo"
+)
+
 var subsysName map[uint]string = map[uint]string{
-	1: "os",
-	2: "agent",
-	3: "mysql",
-	4: "mongo",
+	SubsystemOS:    SubsystemNameOS,
+	SubsystemAgent: SubsystemNameAgent,
+	SubsystemMySQL: SubsystemNameMySQL,
+	SubsystemMongo: SubsystemNameMongo,
 }
 
 var subsys map[string]proto.Subsystem = map[string]proto.Subsystem{
-	"os": {
+	SubsystemNameOS: {
 		Id:       1,
 		ParentId: 0,
-		Name:     "os",
+		Name:     SubsystemNameOS,
 		Label:    "OS",
 	},
-	"agent": {
+	SubsystemNameAgent: {
 		Id:       2,
 		ParentId: 1,
-		Name:     "agent",
+		Name:     SubsystemNameAgent,
 		Label:    "Agent",
 	},
-	"mysql": {
+	SubsystemNameMySQL: {
 		Id:       3,
 		ParentId: 1,
-		Name:     "mysql",
+		Name:     SubsystemNameMySQL,
 		Label:    "MySQL",
 	},
-	"mongo": {
+	SubsystemNameMongo: {
 		Id:       4,
 		ParentId: 1,
-		Name:     "mongo",
+		Name:     SubsystemNameMongo,
 		Label:    "MongoDB",
 	},
 }

--- a/app/instance/subsystem_test.go
+++ b/app/instance/subsystem_test.go
@@ -1,0 +1,34 @@
+/*
+   Copyright (c) 2016, Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package instance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSubsystemByIdEqualByName(t *testing.T) {
+	for id, name := range subsysName {
+		subById, err := GetSubsystemById(id)
+		assert.Nil(t, err)
+		subByName, err := GetSubsystemByName(name)
+		assert.Nil(t, err)
+		assert.Equal(t, subById, subByName)
+	}
+}

--- a/app/qan/data.go
+++ b/app/qan/data.go
@@ -36,7 +36,7 @@ const (
 	THROTTLE_CODE = 299
 )
 
-func SaveData(wsConn ws.Connector, agentId uint, agentVersion string, dbh *MySQLMetricWriter, stats *stats.Stats) error {
+func SaveData(wsConn ws.Connector, agentId uint, dbh *MySQLMetricWriter, stats *stats.Stats) error {
 	prefix := fmt.Sprintf("[qan.SaveData] agent_id=%d", agentId)
 
 	nMsgs := 0

--- a/app/qan/data_test.go
+++ b/app/qan/data_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/percona/pmm/proto"
 	qp "github.com/percona/pmm/proto/qan"
 	"github.com/percona/qan-api/app/db"
+	"github.com/percona/qan-api/app/instance"
 	"github.com/percona/qan-api/app/qan"
 	"github.com/percona/qan-api/config"
 	"github.com/percona/qan-api/service/query"
@@ -60,8 +61,11 @@ func (s *DataTestSuite) SetUpSuite(t *C) {
 	s.mini = query.NewMini(config.ApiRootDir + "/service/query")
 	go s.mini.Run()
 
+	// Create instance handler
+	ih := instance.NewMySQLHandler(db.DBManager)
+
 	// Make real dbh.
-	s.dbh = qan.NewMySQLMetricWriter(db.DBManager, s.mini, stats.NullStats())
+	s.dbh = qan.NewMySQLMetricWriter(db.DBManager, ih, s.mini, stats.NullStats())
 
 	// Make aux MySQL connection.
 	s.db, err = sql.Open("mysql", dsn)
@@ -106,7 +110,7 @@ func (s *DataTestSuite) TestSaveData(t *C) {
 	// Call SaveData which will wait on wsConn.RecvBytes().
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- qan.SaveData(s.wsConn, 2, "1.0.0", s.dbh, stats.NullStats())
+		errChan <- qan.SaveData(s.wsConn, 2, s.dbh, stats.NullStats())
 	}()
 
 	// Send data, wait for a response.
@@ -124,5 +128,7 @@ func (s *DataTestSuite) TestSaveData(t *C) {
 	err = <-errChan
 	t.Check(err, Equals, io.EOF)
 
-	assert.Equal(t, s.testDb.TableGot("query_class_metrics", "query_class_id,instance_id"), s.testDb.TableExpected(config.ApiRootDir+"/test/qan/002/qcm.tab"))
+	expected := s.testDb.TableExpected(config.ApiRootDir + "/test/qan/002/qcm.tab")
+	got := s.testDb.TableGot("query_class_metrics", "query_class_id,instance_id")
+	assert.Equal(t, expected, got)
 }


### PR DESCRIPTION
The fingerprint from agent is parsed as MySQL fingerprint and so we can see malformed results as below:

![image](https://cloud.githubusercontent.com/assets/450355/24959922/7904fba8-1f94-11e7-8e8e-fb3a62294c65.png)

This PR is to avoid parsing Mongo fingerprint as MySQL fingerprint in the API.