### PR TITLE
PMM-1941 Fix fingerprint storage bug

### DIFF
--- a/app/qan/mysql.go
+++ b/app/qan/mysql.go
@@ -353,7 +353,9 @@ func (h *MySQLMetricWriter) getQueryAndTables(class *event.Class) (query.QueryIn
 		bytes, _ := json.Marshal(query.Tables)
 		tables = string(bytes)
 	}
-
+	// We still want to store the fingerprint in the database
+	// even if an example is available
+	query.Query = class.Fingerprint
 	return query, tables, nil
 }
 


### PR DESCRIPTION
Currently, QAN-API passes the query example, if it's available, to `mini` to generate the query abstract but accidentally stores example query as the `fingerprint`.

This patch fixes this behavior by having `getQueryAndTables` always set `query.Query = class.Fingerprint` so that the actual fingerprint is stored.